### PR TITLE
#403 Recalculation secondary unit quantity

### DIFF
--- a/account_invoice_secondary_unit/__manifest__.py
+++ b/account_invoice_secondary_unit/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Account Invoice Scondary UoM ',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Accounting',

--- a/account_invoice_secondary_unit/models/sale_order_line.py
+++ b/account_invoice_secondary_unit/models/sale_order_line.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, api
+from odoo.tools.float_utils import float_round
 
 
 class SaleOrderLine(models.Model):
@@ -12,6 +13,16 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
         if self.secondary_uom_id:
-            res['secondary_uom_qty'] = self.secondary_uom_qty
+            res['secondary_uom_qty'] = self._get_secondary_uom_qty()
             res['secondary_uom_id'] = self.secondary_uom_id.id
         return res
+
+    @api.multi
+    def _get_secondary_uom_qty(self):
+        factor = self.secondary_uom_id.factor * \
+            self.product_uom.factor
+        rounding_factor = self.secondary_uom_id.uom_id.factor
+        return float_round(
+            self.qty_delivered / (factor or 1.0),
+            precision_rounding=rounding_factor
+        )

--- a/account_invoice_secondary_unit/models/sale_order_line.py
+++ b/account_invoice_secondary_unit/models/sale_order_line.py
@@ -13,16 +13,17 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
         if self.secondary_uom_id:
-            res['secondary_uom_qty'] = self._get_secondary_uom_qty()
+            res['secondary_uom_qty'] = self._get_secondary_uom_qty(qty)
             res['secondary_uom_id'] = self.secondary_uom_id.id
         return res
 
     @api.multi
-    def _get_secondary_uom_qty(self):
+    def _get_secondary_uom_qty(self, qty):
+        self.ensure_one()
         factor = self.secondary_uom_id.factor * \
             self.product_uom.factor
         rounding_factor = self.secondary_uom_id.uom_id.factor
         return float_round(
-            self.qty_delivered / (factor or 1.0),
+            qty / (factor or 1.0),
             precision_rounding=rounding_factor
         )


### PR DESCRIPTION
## Summary

* When creating an invoice, Recalculate the secondary unit quantity based on the delivered quantity.
* Such as split delivery, the quantity of the sales order may differ from the delivered quantity.