### PR TITLE
#237 fix _onchange_partner_shipping_id

### DIFF
--- a/sale_order_invoice_address_propose/__manifest__.py
+++ b/sale_order_invoice_address_propose/__manifest__.py
@@ -2,17 +2,17 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Sale Order Invoice Address Propose',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Sales',
     'license': "AGPL-3",
     'description': """
-Add "Invoice Address" to contact model, propose the set "Invoice Address" of 
-the sale order if the "Delivery Address" is selected 
+Add Invoice Address to contact model, and propose Invoice Address of 
+the sales order based on the selected Delivery Address.
     """,
     'depends': [
-        'sale',
+        'sale_stock',
     ],
     'data': [
         'views/res_partner_views.xml',

--- a/sale_order_invoice_address_propose/models/res_partner.py
+++ b/sale_order_invoice_address_propose/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api
+from odoo import models, fields
 
 
 class ResPartner(models.Model):

--- a/sale_order_invoice_address_propose/models/sale_order.py
+++ b/sale_order_invoice_address_propose/models/sale_order.py
@@ -15,7 +15,9 @@ class SaleOrder(models.Model):
 
     @api.onchange('partner_shipping_id')
     def _onchange_partner_shipping_id(self):
+        res = super(SaleOrder, self)._onchange_partner_shipping_id()
         if self.partner_shipping_id and \
                 self.partner_shipping_id.invoice_partner_id:
             self.partner_invoice_id = \
                 self.partner_shipping_id.invoice_partner_id
+        return res


### PR DESCRIPTION
Before this fix, `_onchange_partner_shipping_id` was not triggered due to inappropriate dependency.