### PR TITLE
[FIX] sale_view_adj_hls: remove addition of invisible attr

### DIFF
--- a/sale_view_adj_hls/README.rst
+++ b/sale_view_adj_hls/README.rst
@@ -19,6 +19,9 @@ Sale View Adj HLS
 
 |badge1| |badge2| |badge3| 
 
+This module does the following:
+
+* Adjusts the presentation of sales order views.
 
 **Table of contents**
 

--- a/sale_view_adj_hls/__manifest__.py
+++ b/sale_view_adj_hls/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2019 Quartile Limited
+# Copyright 2019-2020 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Sale View Adj HLS",
     "summary": "",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     "category": "Sales",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/sale_view_adj_hls/readme/DESCRIPTION.rst
+++ b/sale_view_adj_hls/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module does the following:
+
+* Adjusts the presentation of sales order views.

--- a/sale_view_adj_hls/static/description/index.html
+++ b/sale_view_adj_hls/static/description/index.html
@@ -368,6 +368,10 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/qrtl/hls-custom/tree/12.0/sale_view_adj_hls"><img alt="qrtl/hls-custom" src="https://img.shields.io/badge/github-qrtl%2Fhls--custom-lightgray.png?logo=github" /></a></p>
+<p>This module does the following:</p>
+<ul class="simple">
+<li>Adjusts the presentation of sales order views.</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/sale_view_adj_hls/views/sale_order_views.xml
+++ b/sale_view_adj_hls/views/sale_order_views.xml
@@ -31,17 +31,6 @@
         </field>
     </record>
 
-    <record id="view_order_form_inherit_sale_stock" model="ir.ui.view">
-        <field name="name">view.order.form.inherit.sale.stock</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='warehouse_id']" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </xpath>
-        </field>
-    </record>
-
     <record id="view_quotation_tree" model="ir.ui.view">
         <field name="name">sale.order.tree</field>
         <field name="model">sale.order</field>


### PR DESCRIPTION
When a field is made invisible, onchange or default setting associated
with the field stops working. Therefore we will just leave the field
where it is for now.