### PR TITLE
12.0 [FIX][1545] stock_outgoing_shipment_report add date filter

### DIFF
--- a/stock_outgoing_shipment_report/__init__.py
+++ b/stock_outgoing_shipment_report/__init__.py
@@ -1,3 +1,2 @@
 from . import controllers
 from . import models
-from . import report

--- a/stock_outgoing_shipment_report/__manifest__.py
+++ b/stock_outgoing_shipment_report/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2020 Quartile Limited
+# Copyright 2020-2021 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Stock Outgoing Shipment Report",
     "summary": "",
-    "version": "12.0.1.0.2",
+    "version": "12.0.1.1.0",
     "category": "Stock",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",
@@ -16,6 +16,7 @@
         "stock_secondary_unit",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "data/stock_outgoing_shipment_report_data.xml",
         "views/delivery_carrier_views.xml",
         "views/res_partner_views.xml",

--- a/stock_outgoing_shipment_report/__manifest__.py
+++ b/stock_outgoing_shipment_report/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock Outgoing Shipment Report",
     "summary": "",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     "category": "Stock",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/stock_outgoing_shipment_report/i18n/ja.po
+++ b/stock_outgoing_shipment_report/i18n/ja.po
@@ -224,3 +224,17 @@ msgstr "郵便番号"
 msgid "stock.outgoing.shipment.report"
 msgstr ""
 
+#. module: stock_outgoing_shipment_report
+#: model_terms:ir.ui.view,arch_db:stock_outgoing_shipment_report.view_stock_outgoing_shipment_report_search
+msgid "Created Today"
+msgstr "本日作成"
+
+#. module: stock_outgoing_shipment_report
+#: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__date_created
+msgid "Created Date (Date Only)"
+msgstr "作成日(日付のみ)"
+
+#. module: stock_outgoing_shipment_report
+#: model_terms:ir.ui.view,arch_db:stock_outgoing_shipment_report.view_stock_outgoing_shipment_report_search
+msgid "Created Date"
+msgstr "作成日"

--- a/stock_outgoing_shipment_report/i18n/ja.po
+++ b/stock_outgoing_shipment_report/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-03 09:27+0000\n"
-"PO-Revision-Date: 2020-11-03 09:27+0000\n"
+"POT-Creation-Date: 2021-07-27 08:53+0000\n"
+"PO-Revision-Date: 2021-07-27 08:53+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_outgoing_shipment_report
-#: code:addons/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py:91
+#: code:addons/stock_outgoing_shipment_report/models/stock_outgoing_shipment_report.py:97
 #, python-format
 msgid "%s should be at most %s digit(s)."
 msgstr "%sには%s桁までを入れてください。"
@@ -27,7 +27,9 @@ msgid "Address"
 msgstr "住所"
 
 #. module: stock_outgoing_shipment_report
+#: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__carrier_id
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__carrier_name
+#: model_terms:ir.ui.view,arch_db:stock_outgoing_shipment_report.view_stock_outgoing_shipment_report_search
 msgid "Carrier"
 msgstr "配送会社"
 
@@ -72,8 +74,8 @@ msgid "Customer Reference"
 msgstr "発注番号"
 
 #. module: stock_outgoing_shipment_report
-#: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__dispatch_date
-msgid "Dispatch Date"
+#: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__delivery_date
+msgid "Delivery Date"
 msgstr "出庫日"
 
 #. module: stock_outgoing_shipment_report
@@ -93,14 +95,14 @@ msgid "Delivery Time"
 msgstr "納品指定事項"
 
 #. module: stock_outgoing_shipment_report
+#: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__dispatch_date
+msgid "Dispatch Date"
+msgstr "出庫日"
+
+#. module: stock_outgoing_shipment_report
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__display_name
 msgid "Display Name"
 msgstr "表示名"
-
-#. module: stock_outgoing_shipment_report
-#: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__delivery_date
-msgid "Delivery Date"
-msgstr "納品日"
 
 #. module: stock_outgoing_shipment_report
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__expiry_date
@@ -117,6 +119,16 @@ msgstr "賞味期限 (編集)"
 #: model:ir.actions.server,name:stock_outgoing_shipment_report.action_generate_stock_outgoing_shipment_report
 msgid "Generate Delivery Data"
 msgstr "出庫指示データ出力"
+
+#. module: stock_outgoing_shipment_report
+#: model_terms:ir.ui.view,arch_db:stock_outgoing_shipment_report.view_stock_outgoing_shipment_report_search
+msgid "Group By"
+msgstr "グループ化"
+
+#. module: stock_outgoing_shipment_report
+#: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__id
+msgid "ID"
+msgstr ""
 
 #. module: stock_outgoing_shipment_report
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report____last_update
@@ -139,10 +151,15 @@ msgid "Memo"
 msgstr "備考"
 
 #. module: stock_outgoing_shipment_report
-#: code:addons/stock_outgoing_shipment_report/report/stock_outgoing_shipment_report.py:101
+#: code:addons/stock_outgoing_shipment_report/models/stock_outgoing_shipment_report.py:107
 #, python-format
 msgid "Only numbers are allowed for %s field."
 msgstr "%sには数値のみで入力してください。"
+
+#. module: stock_outgoing_shipment_report
+#: model_terms:ir.ui.view,arch_db:stock_outgoing_shipment_report.view_stock_outgoing_shipment_report_search
+msgid "Outgoing Moves"
+msgstr "出荷明細"
 
 #. module: stock_outgoing_shipment_report
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__partner_phone
@@ -158,16 +175,6 @@ msgstr "商品コード"
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__product_name
 msgid "Product Name"
 msgstr "品名"
-
-#. module: stock_outgoing_shipment_report
-#: model:ir.model,name:stock_outgoing_shipment_report.model_product_template
-msgid "Product Template"
-msgstr "プロダクトテンプレート"
-
-#. module: stock_outgoing_shipment_report
-#: model:ir.model,name:stock_outgoing_shipment_report.model_sale_order
-msgid "Sale Order"
-msgstr "販売オーダ"
 
 #. module: stock_outgoing_shipment_report
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__separate_qty
@@ -211,16 +218,6 @@ msgstr "倉庫会社ロット№枝番"
 #: model:ir.model.fields,field_description:stock_outgoing_shipment_report.field_stock_outgoing_shipment_report__partner_zip
 msgid "Zip"
 msgstr "郵便番号"
-
-#. module: stock_outgoing_shipment_report
-#: model:ir.model,name:stock_outgoing_shipment_report.model_delivery_carrier_account
-msgid "delivery.carrier.account"
-msgstr ""
-
-#. module: stock_outgoing_shipment_report
-#: model:ir.model,name:stock_outgoing_shipment_report.model_delivery_carrier_service
-msgid "delivery.carrier.service"
-msgstr ""
 
 #. module: stock_outgoing_shipment_report
 #: model:ir.model,name:stock_outgoing_shipment_report.model_stock_outgoing_shipment_report

--- a/stock_outgoing_shipment_report/models/__init__.py
+++ b/stock_outgoing_shipment_report/models/__init__.py
@@ -1,3 +1,4 @@
 from . import delivery_carrier
 from . import res_partner
+from . import stock_outgoing_shipment_report
 from . import stock_picking

--- a/stock_outgoing_shipment_report/models/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/models/stock_outgoing_shipment_report.py
@@ -23,7 +23,7 @@ FIELDS_PROPERTIES = {
 }
 
 
-class StockOutgoingShipmentReport(models.TransientModel):
+class StockOutgoingShipmentReport(models.Model):
     _name = "stock.outgoing.shipment.report"
 
     move_id = fields.Many2one("stock.move", string="Stock Move", readonly=True,)
@@ -34,6 +34,7 @@ class StockOutgoingShipmentReport(models.TransientModel):
         string="Delivery Date", compute="_compute_date_fields", store=True
     )
     shipping_mode = fields.Char("Shipping Mode")
+    carrier_id = fields.Many2one("delivery.carrier")
     carrier_name = fields.Char("Carrier")
     partner_name = fields.Char("Customer")
     partner_ref = fields.Char("Customer Code")

--- a/stock_outgoing_shipment_report/models/stock_outgoing_shipment_report.py
+++ b/stock_outgoing_shipment_report/models/stock_outgoing_shipment_report.py
@@ -55,6 +55,9 @@ class StockOutgoingShipmentReport(models.Model):
     customer_delivery_note = fields.Char("Customer Delivery Note")
     client_order_ref = fields.Char("Customer Reference")
     memo = fields.Char("Memo")
+    date_created = fields.Date(
+        "Created Date (Date Only)", default=fields.Date.context_today, store=True,
+    )
 
     @api.multi
     @api.depends(

--- a/stock_outgoing_shipment_report/models/stock_picking.py
+++ b/stock_outgoing_shipment_report/models/stock_picking.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Quartile Limited
+# Copyright 2021 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import api, models
@@ -7,32 +7,39 @@ from odoo import api, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
+    def _get_partner_vals(self, partner):
+        partner_address = partner._get_shipping_address()
+        return {
+            "partner_ref": partner.ref[:10] if partner.ref else False,
+            "partner_zip": partner.zip[:8] if partner.zip else False,
+            "partner_name": partner.display_name,
+            "partner_address": partner_address[:80] if partner_address else False,
+            "partner_phone": partner.phone[:12] if partner.phone else False,
+            "customer_delivery_note": partner.delivery_time,
+        }
+
     @api.multi
     def generate_stock_outgoing_shipment_report(self):
+        report_obj = self.env["stock.outgoing.shipment.report"]
         moves = self.mapped("move_lines")
-        self._cr.execute("DELETE FROM stock_outgoing_shipment_report")
         for move in moves:
             order = move.group_id.sale_id
             partner = move.picking_partner_id
             product = move.product_id
-            partner_address = partner._get_shipping_address()
             vals = {
                 "move_id": move.id,
                 "shipping_mode": order.carrier_id.shipping_mode,
+                "carrier_id": order.carrier_id.id if order else False,
                 "carrier_name": order.carrier_id.name[:20]
-                if order and order.carrier_id and len(order.carrier_id.name) > 20
-                else order and order.carrier_id and order.carrier_id.name or False,
+                if order and order.carrier_id
+                else False,
                 "product_code": product.default_code[:7]
-                if product and product.default_code and len(product.default_code) > 7
-                else product and product.default_code,
-                "product_name": product.name[:32]
-                if product and len(product.name) > 32
-                else product and product.name,
+                if product and product.default_code
+                else False,
+                "product_name": product.name[:32],
                 "client_order_ref": move.sale_line_id
                 and move.sale_line_id.client_order_ref,
-                "memo": move.note[:9]
-                if move.note and len(move.note) > 9
-                else move.note,
+                "memo": move.note[:9] if move.note else False,
             }
             secondary_uom = move.product_id.stock_secondary_uom_id
             if secondary_uom:
@@ -46,25 +53,10 @@ class StockPicking(models.Model):
                     }
                 )
             if partner:
-                vals.update(
-                    {
-                        "partner_ref": partner.ref[:10]
-                        if partner.ref and len(partner.ref) > 10
-                        else partner.ref,
-                        "partner_zip": partner.zip[:8]
-                        if partner.zip and len(partner.zip) > 8
-                        else partner.zip,
-                        "partner_name": partner.display_name,
-                        "partner_address": partner_address[:80]
-                        if len(partner_address) > 80
-                        else partner_address,
-                        "partner_phone": partner.phone[:12]
-                        if partner.phone and len(partner.phone) > 12
-                        else partner and partner.phone,
-                        "customer_delivery_note": partner.delivery_time,
-                    }
-                )
-            self.env["stock.outgoing.shipment.report"].create(vals)
+                partner_vals = self._get_partner_vals(partner)
+                vals.update(partner_vals)
+            move_rec = report_obj.search([("move_id", "=", move.id)])
+            move_rec.write(vals) if move_rec else report_obj.create(vals)
         return self.env.ref(
             "stock_outgoing_shipment_report.action_stock_outgoing_shipment_report"
         ).read()[0]

--- a/stock_outgoing_shipment_report/report/__init__.py
+++ b/stock_outgoing_shipment_report/report/__init__.py
@@ -1,1 +1,0 @@
-from . import stock_outgoing_shipment_report

--- a/stock_outgoing_shipment_report/security/ir.model.access.csv
+++ b/stock_outgoing_shipment_report/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_outgoing_shipment_report_user,access.stock.outgoing.shipment.report.user,model_stock_outgoing_shipment_report,base.group_user,1,0,0,0
+access_stock_outgoing_shipment_report_stock_user,access.stock.outgoing.shipment.report.stock.user,model_stock_outgoing_shipment_report,stock.group_stock_user,1,1,1,1

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -6,6 +6,8 @@
         <field name="arch" type="xml">
             <search string="Outgoing Moves">
                 <field name="carrier_id" />
+                <filter name="createdtoday" string="Created Today" domain="[('create_date','&gt;=', datetime.datetime.combine(context_today(), datetime.time(0,0,0))), ('create_date','&lt;=', datetime.datetime.combine(context_today(), datetime.time(23,59,59)))]"/>
+                <filter name="date_created" string="Created Date" date="date_created" />
                 <group expand="0" string="Group By">
                     <filter name="group_by_carrier" string="Carrier" context="{'group_by':'carrier_id'}"/>
                 </group>
@@ -46,6 +48,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree</field>
+        <field name="context">{"search_default_createdtoday": 1}</field>
     </record>
     <menuitem
         action="action_stock_outgoing_shipment_report"

--- a/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
+++ b/stock_outgoing_shipment_report/views/stock_outgoing_shipment_report_views.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="view_stock_outgoing_shipment_report_search" model="ir.ui.view">
+        <field name="name">stock.outgoing.shipment.report.search</field>
+        <field name="model">stock.outgoing.shipment.report</field>
+        <field name="arch" type="xml">
+            <search string="Outgoing Moves">
+                <field name="carrier_id" />
+                <group expand="0" string="Group By">
+                    <filter name="group_by_carrier" string="Carrier" context="{'group_by':'carrier_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
     <record id="view_stock_outgoing_shipment_report_tree" model="ir.ui.view">
         <field name="name">stock.outgoing.shipment.report.tree</field>
         <field name="model">stock.outgoing.shipment.report</field>
@@ -38,7 +50,7 @@
     <menuitem
         action="action_stock_outgoing_shipment_report"
         id="stock_outgoing_shipment_report_menu"
-        parent="stock.menu_warehouse_report"
-        sequence="170"
+        parent="stock.menu_stock_warehouse_mgmt"
+        sequence="3"
     />
 </odoo>


### PR DESCRIPTION
[1545](https://www.quartile.co/web?debug=1#id=1545&action=771&model=project.task&view_type=form&menu_id=505)

#140 
- Switch the model from transient to regular model to avoid the record deletion.
- Change the menu path of the Outgoing Shipment Report.
- Simplify the logic.

#145 
- Add created_today and date_created filter
- Add date_created field for filtering only date, without time.