### PR TITLE
st2 [1961][IMP] stock_production_lot_name_adj

### DIFF
--- a/stock_production_lot_name_adj/README.rst
+++ b/stock_production_lot_name_adj/README.rst
@@ -21,7 +21,10 @@ Stock Production Lot Name Adj
 
 This module does the following:
 
-* Makes the display name format of the lot/serial "[yyyy/mm/dd] Lot Name", showing the removal date in 'yyyy/mm/dd' part.
+* Makes the display name format of the lot/serial "[yyyy/mm/dd] Lot Name", showing the
+  removal date in 'yyyy/mm/dd' part.
+* Makes the lot searcheable by the removal date string (fields are added to
+  stock.production.lot for this purpose).
 
 **Table of contents**
 

--- a/stock_production_lot_name_adj/__init__.py
+++ b/stock_production_lot_name_adj/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/stock_production_lot_name_adj/__manifest__.py
+++ b/stock_production_lot_name_adj/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Quartile Limited
+# Copyright 2020-2022 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Stock Production Lot Name Adj",
@@ -8,5 +8,6 @@
     "category": "Stock",
     "license": "LGPL-3",
     "depends": ["product_expiry"],
+    "post_init_hook": "post_init_hook",
     "installable": True,
 }

--- a/stock_production_lot_name_adj/hooks.py
+++ b/stock_production_lot_name_adj/hooks.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import SUPERUSER_ID, api, fields
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    lots = env["stock.production.lot"].search([("removal_date_str1", "=", False)])
+    for lot in lots.with_context(tz="Japan"):
+        if lot.removal_date:
+            removal_date = fields.Datetime.context_timestamp(lot, lot.removal_date)
+            lot.removal_date_str1 = removal_date.date().strftime("%Y%m%d")
+            lot.removal_date_str2 = removal_date.date().strftime("%Y-%m-%d")
+            lot.removal_date_str3 = removal_date.date().strftime("%Y/%m/%d")

--- a/stock_production_lot_name_adj/models/stock_production_lot.py
+++ b/stock_production_lot_name_adj/models/stock_production_lot.py
@@ -1,21 +1,65 @@
-# Copyright 2020 Quartile Limited
+# Copyright 2020-2022 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class StockProductionLot(models.Model):
     _inherit = "stock.production.lot"
+
+    removal_date_str1 = fields.Char(
+        compute="_compute_removal_date_string", store=True, copy=False,
+    )
+    removal_date_str2 = fields.Char(
+        compute="_compute_removal_date_string", store=True, copy=False,
+    )
+    removal_date_str3 = fields.Char(
+        compute="_compute_removal_date_string", store=True, copy=False,
+    )
+
+    @api.depends("removal_date")
+    def _compute_removal_date_string(self):
+        # Apply company's timezone if available.
+        tz = self.env.user.company_id.partner_id.tz or "Japan"
+        for lot in self.with_context(tz=tz):
+            if lot.removal_date:
+                removal_date = fields.Datetime.context_timestamp(self, lot.removal_date)
+                lot.removal_date_str1 = removal_date.date().strftime("%Y/%m/%d")
+                lot.removal_date_str2 = removal_date.date().strftime("%Y-%m-%d")
+                lot.removal_date_str3 = removal_date.date().strftime("%Y%m%d")
 
     @api.multi
     def name_get(self):
         result = []
         for lot in self:
             name = lot.name
-            if lot.removal_date:
-                # Convert removal_date to user's timezone. The design decision
-                # here is to use user's timezone, instead of superuser's.
-                removal_date = fields.Datetime.context_timestamp(self, lot.removal_date)
-                name = "[" + removal_date.date().strftime("%Y/%m/%d") + "] " + lot.name
+            if lot.removal_date_str1:
+                name = "[" + lot.removal_date_str1 + "] " + lot.name
             result.append((lot.id, name))
         return result
+
+    @api.model
+    def _name_search(
+        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
+        args = args or []
+        domain = []
+        if name:
+            # Tried below first and it turned out that the search with the date (e.g.
+            # '2023-09-01') on removal_date somehow wouldn't work.
+            # domain = ['|', ('removal_date', '=like', '%' + name.replace('/', '-') + '%'), ('name', operator, name)]  # noqa
+            removal_date = "%" + name + "%"
+            domain = [
+                "|",
+                "|",
+                "|",
+                ("removal_date_str1", operator, removal_date),
+                ("removal_date_str2", operator, removal_date),
+                ("removal_date_str3", operator, removal_date),
+                ("name", operator, name),
+            ]
+        lot_ids = self._search(
+            expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid
+        )
+        return self.browse(lot_ids).name_get()

--- a/stock_production_lot_name_adj/readme/DESCRIPTION.rst
+++ b/stock_production_lot_name_adj/readme/DESCRIPTION.rst
@@ -1,3 +1,6 @@
 This module does the following:
 
-* Makes the display name format of the lot/serial "[yyyy/mm/dd] Lot Name", showing the removal date in 'yyyy/mm/dd' part.
+* Makes the display name format of the lot/serial "[yyyy/mm/dd] Lot Name", showing the
+  removal date in 'yyyy/mm/dd' part.
+* Makes the lot searcheable by the removal date string (fields are added to
+  stock.production.lot for this purpose).

--- a/stock_production_lot_name_adj/static/description/index.html
+++ b/stock_production_lot_name_adj/static/description/index.html
@@ -370,7 +370,10 @@ ul.auto-toc {
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/qrtl/hls-custom/tree/12.0/stock_production_lot_name_adj"><img alt="qrtl/hls-custom" src="https://img.shields.io/badge/github-qrtl%2Fhls--custom-lightgray.png?logo=github" /></a></p>
 <p>This module does the following:</p>
 <ul class="simple">
-<li>Makes the display name format of the lot/serial “[yyyy/mm/dd] Lot Name”, showing the removal date in ‘yyyy/mm/dd’ part.</li>
+<li>Makes the display name format of the lot/serial “[yyyy/mm/dd] Lot Name”, showing the
+removal date in ‘yyyy/mm/dd’ part.</li>
+<li>Makes the lot searcheable by the removal date string (fields are added to
+stock.production.lot for this purpose).</li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">

--- a/stock_production_lot_name_adj/tests/test_stock_production_lot_name.py
+++ b/stock_production_lot_name_adj/tests/test_stock_production_lot_name.py
@@ -1,33 +1,48 @@
-# Copyright 2020 Quartile Limited
+# Copyright 2020-2022 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo.tests.common import TransactionCase
+import odoo.tests.common as common
 
 
-class TestStockProductionLotName(TransactionCase):
-    def setUp(self):
-        super(TestStockProductionLotName, self).setUp()
-        self.product = self.env["product.product"].create(
+class TestStockProductionLotName(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestStockProductionLotName, cls).setUpClass()
+        cls.product = cls.env["product.product"].create(
             {"name": "Product A", "type": "product", "tracking": "lot"}
         )
-        self.user = self.env["res.users"].create(
-            {
-                "name": "test",
-                "login": "test",
-                "email": "test@example.com",
-                "tz": "Japan",
-            }
+        cls.user = cls.env["res.users"].create(
+            {"name": "test", "login": "test", "email": "test@example.com"}
         )
-        self.lot_model = self.env["stock.production.lot"]
+        cls.lot_model = cls.env["stock.production.lot"]
 
-    def test_01_lot_name_get(self):
+    def test_lot_name_get(self):
         lot = self.lot_model.sudo(self.user.id).create(
             {"name": "test lot", "product_id": self.product.id}
         )
         self.assertEqual(dict(lot.name_get())[lot.id], "test lot")
 
         lot.write({"removal_date": "2020-07-10 12:00:00"})
+        lot._compute_removal_date_string()
         self.assertEqual(dict(lot.name_get())[lot.id], "[2020/07/10] test lot")
 
-        lot.write({"removal_date": "2020-07-10 18:00:00"})
-        self.assertEqual(dict(lot.name_get())[lot.id], "[2020/07/11] test lot")
+    def test_lot_name_search(self):
+        lot = self.lot_model.sudo(self.user.id).create(
+            {"name": "test lot hoge", "product_id": self.product.id}
+        )
+        lot.write({"removal_date": "2023-05-12 12:00:00"})
+        lot._compute_removal_date_string()
+        args = [("product_id", "=", self.product.id)]
+        lot_res = self.lot_model.name_search(
+            name="2023/05/12", args=args, operator="ilike"
+        )
+        self.assertEqual(len(lot_res), 1)
+        self.assertEqual(lot_res[0][1], "[2023/05/12] test lot hoge")
+        lot_res = self.lot_model.name_search(
+            name="23-05-12", args=args, operator="ilike"
+        )
+        self.assertEqual(len(lot_res), 1)
+        self.assertEqual(lot_res[0][1], "[2023/05/12] test lot hoge")
+        lot_res = self.lot_model.name_search(name="230512", args=args, operator="ilike")
+        self.assertEqual(len(lot_res), 1)
+        self.assertEqual(lot_res[0][1], "[2023/05/12] test lot hoge")


### PR DESCRIPTION
[1961](https://www.quartile.co/web#id=1961&action=771&active_id=2156&model=project.task&view_type=form&menu_id=505)

Makes the lot searchable by the removal date string (fields are added to stock.production.lot for this purpose).

@kakurai8 To update the fields (`removal_date_str1`, `removal_date_str2` and `removal_date_str3`) of the existing lots, you need to first uninstall the module, and then re-install it ([post_init_hook](https://github.com/qrtl/hls-custom/pull/169/files#diff-fc135d8f702a1b183e22d5c5ea6be8c94abb1df3e0be345cd9ffb2722fe74a0dR7) doesn't get kicked at module upgrade).

Supported search formats: full/partial strings of the following:

- yyyy/mm/dd
- yyyy-mm-dd
- yyyymmdd
