### PR TITLE
[6505][FIX] stock_outgoing_shipment_report: Fix access error for stock users

### DIFF
--- a/stock_outgoing_shipment_report/models/stock_picking.py
+++ b/stock_outgoing_shipment_report/models/stock_picking.py
@@ -36,6 +36,6 @@ class StockPicking(models.Model):
                 vals.update(partner_vals)
             move_rec = report_obj.search([("move_id", "=", move.id)])
             move_rec.write(vals) if move_rec else report_obj.create(vals)
-        return self.env.ref(
+        return self.env["ir.actions.act_window"]._for_xml_id(
             "stock_outgoing_shipment_report.action_stock_outgoing_shipment_report"
-        ).read()[0]
+        )


### PR DESCRIPTION
[6505](https://www.quartile.co/web#menu_id=505&cids=3&action=1457&model=project.task&view_type=form&id=6505)

Replace env.ref().read()[0] with _for_xml_id() to avoid ACL check on ir.actions.act_window.
